### PR TITLE
Add system design segment

### DIFF
--- a/Elm-code-test.md
+++ b/Elm-code-test.md
@@ -47,3 +47,5 @@ The Elm app is just the start of a proof of concept. For this system to become a
   - We don't want to handle the users' passwords.
 * A users should be able to create several ratings.
 * A users should be able to edit their ratings, but not other user's ratings.
+
+As mentioned you do not have to actually impement any of this. You only need to present your ideas in the way you see fit and it will be disucssed at the second part of the code review.

--- a/Elm-code-test.md
+++ b/Elm-code-test.md
@@ -1,6 +1,10 @@
 # Elm code and System Design test
 
-## Elm code test
+There are two parts of this test. 
+1. The first is in code where your goal is to improve an existing web app to make it comply with the given new requirements.
+2. In the second part you design the future backend system of the app. No code is needed here but be prepared to go through your idea at the code review meeting.
+
+## Rate it! - Elm code test
 
 This is a code test in [elm-lang](http://elm-lang.org/) which we do not expect you to already know. You are given an existing application and some new requirements.
 Your mission is to fulfill these requirement by changing the code in the existing application.
@@ -12,17 +16,18 @@ These are some useful Elm resources:
 - https://package.elm-lang.org
 - https://guide.elm-lang.org/
 
-### Rate it!
+### The App
 
-In this little webapp you can rate ...it! ...with horses! But what is 'it'?. That doesn't matter.
+In this little webapp you can rate ...it! ...with horses! But what is 'it'?. It is what ever the user want to rate.
 
 The current version of the app can be found here https://ellie-app.com/6PDCnNzpN4Pa1
 
 #### New requirements
 
+- A textinput for the user to enter what thing the rating is concerns. E.g. "Titanic".
 - Instead of the rating being showed as a number, it should be shown as 1 to 6 filled horses (♞).
 - Initially, before any rating has been provided 6 unfilled horses (♘) should be shown.
-- We also need a new "Reset" button that resets the rating.
+- We also need a new "Reset" button that resets the rating input.
 - Would also be nice to have a text field where the user can add a comment to complement the rating
 - Despite having a lot of users only a few of them are Rating it. We suspect it has to do with the UX of the app. If you have any ideas how to make it more attractive to rate it in the app please bring them to the meeting or try implementing them.
 
@@ -34,10 +39,11 @@ Good luck!
 
 ## System Design
 
-The Elm app is just the start of a proof of concept. For this system to become a reality the company needs your help to design the backend system to make this app into a real product. 
+The Elm app is just the start of a proof of concept. For this system to become a reality the company needs your help to design the backend system to make this app into a real product.
 
 ### Requirements on the system
 
-* A user should be able to create several ratings.
-* A user should be able to edit their ratings, but not other user's ratings.
-* 
+* A users should be able to login and see their previous ratings.
+  - We don't want to handle the users' passwords.
+* A users should be able to create several ratings.
+* A users should be able to edit their ratings, but not other user's ratings.

--- a/Elm-code-test.md
+++ b/Elm-code-test.md
@@ -1,4 +1,6 @@
-# Elm code test
+# Elm code and System Design test
+
+## Elm code test
 
 This is a code test in [elm-lang](http://elm-lang.org/) which we do not expect you to already know. You are given an existing application and some new requirements.
 Your mission is to fulfill these requirement by changing the code in the existing application.
@@ -10,22 +12,32 @@ These are some useful Elm resources:
 - https://package.elm-lang.org
 - https://guide.elm-lang.org/
 
-## Rate it!
+### Rate it!
 
 In this little webapp you can rate ...it! ...with horses! But what is 'it'?. That doesn't matter.
 
 The current version of the app can be found here https://ellie-app.com/6PDCnNzpN4Pa1
 
-### New requirements
+#### New requirements
 
 - Instead of the rating being showed as a number, it should be shown as 1 to 6 filled horses (♞).
 - Initially, before any rating has been provided 6 unfilled horses (♘) should be shown.
 - We also need a new "Reset" button that resets the rating.
 - Would also be nice to have a text field where the user can add a comment to complement the rating
-- Despite having a lot of users only a few of them are Rating it. If you have any ideas how to make it more attractive to rate it in the app please bring them to the meeting or try implementing them.
+- Despite having a lot of users only a few of them are Rating it. We suspect it has to do with the UX of the app. If you have any ideas how to make it more attractive to rate it in the app please bring them to the meeting or try implementing them.
 
-### Ship it
+#### Ship it
 
 When you are done with the new requirements hit save in the ellie-app code editor and copy the new URL to the app and email it as a response to the mail where you got the test from. Feel free to leave some comments about the experience and result with the URL.
 
 Good luck!
+
+## System Design
+
+The Elm app is just the start of a proof of concept. For this system to become a reality the company needs your help to design the backend system to make this app into a real product. 
+
+### Requirements on the system
+
+* A user should be able to create several ratings.
+* A user should be able to edit their ratings, but not other user's ratings.
+* 

--- a/Elm-code-test.md
+++ b/Elm-code-test.md
@@ -18,7 +18,7 @@ These are some useful Elm resources:
 
 ### The App
 
-In this little webapp you can rate ...it! ...with horses! But what is 'it'?. It is what ever the user want to rate.
+In this little webapp you can rate ...it! ...with horses! But what is 'it'?. It is whatever the user wants to rate.
 
 The current version of the app can be found here https://ellie-app.com/6PDCnNzpN4Pa1
 

--- a/Elm-code-test.md
+++ b/Elm-code-test.md
@@ -4,7 +4,7 @@ There are two parts of this test.
 1. The first is in code where your goal is to improve an existing web app to make it comply with the given new requirements.
 2. In the second part you design the future backend system of the app. No code is needed here but be prepared to go through your idea at the code review meeting.
 
-## Rate it! - Elm code test
+## 1. Rate it! - Elm code test
 
 This is a code test in [elm-lang](http://elm-lang.org/) which we do not expect you to already know. You are given an existing application and some new requirements.
 Your mission is to fulfill these requirement by changing the code in the existing application.
@@ -37,7 +37,7 @@ When you are done with the new requirements hit save in the ellie-app code edito
 
 Good luck!
 
-## System Design
+## 2. System Design
 
 The Elm app is just the start of a proof of concept. For this system to become a reality the company needs your help to design the backend system to make this app into a real product.
 


### PR DESCRIPTION
Inspired by https://medium.com/@eeue56/my-ideal-engineering-interview-process-b73d7cef9604

### Problem
We don't get to know much about the candidate's knowledge about backend and System Design during our current code test. Since the role is usually "Fullstack" this is probably good to test a bit.

### Solution
Add a System Design part to the code test where the candidate is asked to prepare and present a design for the system during the code review meeting.